### PR TITLE
Fix image printing bugs

### DIFF
--- a/p21_print.py
+++ b/p21_print.py
@@ -295,6 +295,15 @@ def send_command(command):
     except serial.SerialException as e:
         print(f"Failed to send data via serial connection: {e}")
         return
+    
+def send_command_raw(command):
+    try:
+        with serial.Serial(device, 115200, timeout=1) as ser:
+            ser.write(command)
+            return ser.readline()
+    except serial.SerialException as e:
+        print(f"Failed to send data via serial connection: {e}")
+        return
 
 def build_print_command(imagedata, density, copies):
     serial_data = f"""\033!o\r\n
@@ -335,13 +344,9 @@ def main():
     if (args.device):
         device = args.device
     if args.image:
-        ready = get_readiness_status()
-        if ready != PrinterReadinessStatus.READY:
-            print(f"Printer is not ready: {ready}")
-            return
         bitdata = load_image(args.image)
         print_command = build_print_command(bitdata, args.density, args.copies)
-        answer= send_command(print_command)
+        answer= send_command_raw(print_command)
         print(answer.hex())
     if args.config:
         print("Printer configuration:")


### PR DESCRIPTION
- Create new function send_command_raw to avoid double encode of print_command when printing an image
- Remove printer readiness check, as 2 rapid sequential calls to open the rfcomm device appear to cause the following error:
`Failed to send data via serial connection: device reports readiness to read but returned no data (device disconnected or multiple access on port?)`